### PR TITLE
Solveplymemoryleaks

### DIFF
--- a/include/main_engine/tracker/MeshIO.h
+++ b/include/main_engine/tracker/MeshIO.h
@@ -292,6 +292,12 @@ void MeshIO<FloatType>::loadFromPLY(const std::string& filename,
 	/* close the PLY file */
 	ply_close(ply);
 
+	for (int i = 0; i < nelems; i++)
+	{
+		delete elist[i];
+	}
+	delete[] elist;
+
   meshData.numVertices = meshData.vertices.size();
   meshData.numFaces = meshData.facesVerticesInd.size();
 
@@ -635,6 +641,12 @@ void MeshIO<FloatType>::updateFromPLY(const std::string& filename,
 	/* close the PLY file */
 	ply_close(ply);
 
+	for (int i = 0; i < nelems; i++)
+	{
+		delete elist[i];
+	}
+	delete[] elist;
+
   if(vertex_type == PLY_VERTEX_RGBA || vertex_type == PLY_VERTEX_RGB)
     meshData.computeNormalsNeil();
 
@@ -852,8 +864,6 @@ void MeshIO<FloatType>::writeToPLY(const std::string& filename, const MeshData<F
 
 	/* close the PLY file */
 	ply_close(ply);
-
-  delete[] f.verts;
 }
 
 template<class FloatType>

--- a/include/main_engine/utils/global.h
+++ b/include/main_engine/utils/global.h
@@ -22,6 +22,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
+#include <boost/interprocess/mapped_region.hpp>
 
 #ifdef _MSC_VER
 #include "third_party/msvc/Stopwatch.h"

--- a/include/third_party/nanoflann.hpp
+++ b/include/third_party/nanoflann.hpp
@@ -516,7 +516,7 @@ namespace nanoflann
 		 * Returns a pointer to a piece of new memory of the given size in bytes
 		 * allocated from the pool.
 		 */
-		void* malloc(const size_t req_size)
+		void* nanoflann_malloc(const size_t req_size)
 		{
 			/* Round size up to a multiple of wordsize.  The following expression
 			    only works for WORDSIZE that is a power of 2, by masking last bits of
@@ -571,7 +571,7 @@ namespace nanoflann
 		template <typename T>
 		T* allocate(const size_t count = 1)
 		{
-			T* mem = static_cast<T*>(this->malloc(sizeof(T)*count));
+			T* mem = static_cast<T*>(this->nanoflann_malloc(sizeof(T)*count));
 			return mem;
 		}
 

--- a/msvc/ConsoleApp/ConsoleApp.vcxproj
+++ b/msvc/ConsoleApp/ConsoleApp.vcxproj
@@ -99,13 +99,13 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;GLOG_NO_ABBREVIATED_SEVERITIES;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(LMDB_PATH)\liblmdb</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(LMDB_PATH)\liblmdb;$(HDF5_PATH)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\x64\Debug;$(GLUT_ROOT)\lib;$(GLEW_ROOT)\lib;$(BOOST_ROOT)\stage\lib;$(SUITESPARSE_PATH)\lib64\lapack_blas_windows;$(SUITESPARSE_PATH)\lib64;$(OPENCV_PATH)\x64\vc12\lib;$(CERES_PATH)\lib;$(GLOG_PATH)\x64\Debug;$(LMDB_PATH)\X64\Debug</AdditionalLibraryDirectories>
-      <AdditionalDependencies>MainEngine.lib;opencv_core300d.lib;opencv_highgui300d.lib;opencv_imgcodecs300d.lib;opencv_imgproc300d.lib;libblas.lib;liblapack.lib;libamdd.lib;libbtfd.lib;libcamdd.lib;libccolamdd.lib;libcholmodd.lib;libcolamdd.lib;libcxsparsed.lib;libklud.lib;libldld.lib;libspqrd.lib;libumfpackd.lib;suitesparseconfigd.lib;libglog_d.lib;ceres-debug.lib;freeglutd.lib;GLU32.lib;OPENGL32.lib;glew32.lib;Ws2_32.lib;libboost_filesystem-vc120-mt-gd-1_59.lib;lmdb.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\x64\Debug;$(GLUT_ROOT)\lib;$(GLEW_ROOT)\lib;$(BOOST_ROOT)\stage\lib;$(SUITESPARSE_PATH)\lib64\lapack_blas_windows;$(SUITESPARSE_PATH)\lib64;$(OPENCV_PATH)\x64\vc12\lib;$(CERES_PATH)\lib;$(GLOG_PATH)\x64\Debug;$(LMDB_PATH)\X64\Debug;$(HDF5_PATH)\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>MainEngine.lib;opencv_core300d.lib;opencv_highgui300d.lib;opencv_imgcodecs300d.lib;opencv_imgproc300d.lib;libblas.lib;liblapack.lib;libamdd.lib;libbtfd.lib;libcamdd.lib;libccolamdd.lib;libcholmodd.lib;libcolamdd.lib;libcxsparsed.lib;libklud.lib;libldld.lib;libspqrd.lib;libumfpackd.lib;suitesparseconfigd.lib;libglog_d.lib;ceres-debug.lib;freeglutd.lib;GLU32.lib;OPENGL32.lib;glew32.lib;Ws2_32.lib;libboost_filesystem-vc120-mt-gd-1_59.lib;lmdb.lib;libhdf5.lib;libhdf5_hl.lib;libhdf5_tools.lib;libszip.lib;libzlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -135,15 +135,15 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;GLOG_NO_ABBREVIATED_SEVERITIES;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(LMDB_PATH)\liblmdb</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(LMDB_PATH)\liblmdb;$(HDF5_PATH)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(SolutionDir)\x64\Release;$(GLUT_ROOT)\lib;$(GLEW_ROOT)\lib;$(BOOST_ROOT)\stage\lib;$(SUITESPARSE_PATH)\lib64\lapack_blas_windows;$(SUITESPARSE_PATH)\lib64;$(OPENCV_PATH)\x64\vc12\lib;$(CERES_PATH)\lib;$(GLOG_PATH)\x64\Release;$(LMDB_PATH)\X64\Release</AdditionalLibraryDirectories>
-      <AdditionalDependencies>MainEngine.lib;opencv_core300.lib;opencv_highgui300.lib;opencv_imgcodecs300.lib;opencv_imgproc300.lib;libblas.lib;liblapack.lib;libamdd.lib;libbtfd.lib;libcamd.lib;libccolamd.lib;libcholmod.lib;libcolamd.lib;libcxsparse.lib;libklu.lib;libldl.lib;libspqr.lib;libumfpack.lib;suitesparseconfig.lib;libglog.lib;ceres.lib;freeglut.lib;GLU32.lib;OPENGL32.lib;glew32.lib;Ws2_32.lib;libboost_filesystem-vc120-mt-1_59.lib;lmdb.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\x64\Release;$(GLUT_ROOT)\lib;$(GLEW_ROOT)\lib;$(BOOST_ROOT)\stage\lib;$(SUITESPARSE_PATH)\lib64\lapack_blas_windows;$(SUITESPARSE_PATH)\lib64;$(OPENCV_PATH)\x64\vc12\lib;$(CERES_PATH)\lib;$(GLOG_PATH)\x64\Release;$(LMDB_PATH)\X64\Release;$(HDF5_PATH)\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>MainEngine.lib;opencv_core300.lib;opencv_highgui300.lib;opencv_imgcodecs300.lib;opencv_imgproc300.lib;libblas.lib;liblapack.lib;libamdd.lib;libbtfd.lib;libcamd.lib;libccolamd.lib;libcholmod.lib;libcolamd.lib;libcxsparse.lib;libklu.lib;libldl.lib;libspqr.lib;libumfpack.lib;suitesparseconfig.lib;libglog.lib;ceres.lib;freeglut.lib;GLU32.lib;OPENGL32.lib;glew32.lib;Ws2_32.lib;libboost_filesystem-vc120-mt-1_59.lib;lmdb.lib;libhdf5.lib;libhdf5_hl.lib;libhdf5_tools.lib;libszip.lib;libzlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/msvc/GUIApp/GUIApp.vcxproj
+++ b/msvc/GUIApp/GUIApp.vcxproj
@@ -99,13 +99,13 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;GLOG_NO_ABBREVIATED_SEVERITIES;WIN32_LEAN_AND_MEAN;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(WXWIN)\include\msvc;$(WXWIN)\include;$(LMDB_PATH)\liblmdb</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(WXWIN)\include\msvc;$(WXWIN)\include;$(LMDB_PATH)\liblmdb;$(HDF5_PATH)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\x64\Debug;$(GLUT_ROOT)\lib;$(GLEW_ROOT)\lib;$(BOOST_ROOT)\stage\lib;$(SUITESPARSE_PATH)\lib64\lapack_blas_windows;$(SUITESPARSE_PATH)\lib64;$(OPENCV_PATH)\x64\vc12\lib;$(CERES_PATH)\lib;$(GLOG_PATH)\x64\Debug;$(WXWIN)\lib\vc_x64_lib;$(LMDB_PATH)\X64\Debug</AdditionalLibraryDirectories>
-      <AdditionalDependencies>MainEngine.lib;opencv_core300d.lib;opencv_highgui300d.lib;opencv_imgcodecs300d.lib;opencv_imgproc300d.lib;libblas.lib;liblapack.lib;libamdd.lib;libbtfd.lib;libcamdd.lib;libccolamdd.lib;libcholmodd.lib;libcolamdd.lib;libcxsparsed.lib;libklud.lib;libldld.lib;libspqrd.lib;libumfpackd.lib;suitesparseconfigd.lib;libglog_d.lib;ceres-debug.lib;freeglutd.lib;GLU32.lib;OPENGL32.lib;glew32.lib;Ws2_32.lib;wxmsw30ud_core.lib;wxbase30ud.lib;wxmsw30ud_gl.lib;wxexpatd.lib;wxjpegd.lib;wxpngd.lib;wxregexud.lib;wxtiffd.lib;wxzlibd.lib;winmm.lib;comctl32.lib;rpcrt4.lib;wsock32.lib;odbc32.lib;libboost_filesystem-vc120-mt-gd-1_59.lib;lmdb.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\x64\Debug;$(GLUT_ROOT)\lib;$(GLEW_ROOT)\lib;$(BOOST_ROOT)\stage\lib;$(SUITESPARSE_PATH)\lib64\lapack_blas_windows;$(SUITESPARSE_PATH)\lib64;$(OPENCV_PATH)\x64\vc12\lib;$(CERES_PATH)\lib;$(GLOG_PATH)\x64\Debug;$(WXWIN)\lib\vc_x64_lib;$(LMDB_PATH)\X64\Debug;$(HDF5_PATH)\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>MainEngine.lib;opencv_core300d.lib;opencv_highgui300d.lib;opencv_imgcodecs300d.lib;opencv_imgproc300d.lib;libblas.lib;liblapack.lib;libamdd.lib;libbtfd.lib;libcamdd.lib;libccolamdd.lib;libcholmodd.lib;libcolamdd.lib;libcxsparsed.lib;libklud.lib;libldld.lib;libspqrd.lib;libumfpackd.lib;suitesparseconfigd.lib;libglog_d.lib;ceres-debug.lib;freeglutd.lib;GLU32.lib;OPENGL32.lib;glew32.lib;Ws2_32.lib;wxmsw30ud_core.lib;wxbase30ud.lib;wxmsw30ud_gl.lib;wxexpatd.lib;wxjpegd.lib;wxpngd.lib;wxregexud.lib;wxtiffd.lib;wxzlibd.lib;winmm.lib;comctl32.lib;rpcrt4.lib;wsock32.lib;odbc32.lib;libboost_filesystem-vc120-mt-gd-1_59.lib;lmdb.lib;libhdf5.lib;libhdf5_hl.lib;libhdf5_tools.lib;libszip.lib;libzlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -135,15 +135,15 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;GLOG_NO_ABBREVIATED_SEVERITIES;WIN32_LEAN_AND_MEAN;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(WXWIN)\include\msvc;$(WXWIN)\include;$(LMDB_PATH)\liblmdb</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(WXWIN)\include\msvc;$(WXWIN)\include;$(LMDB_PATH)\liblmdb;$(HDF5_PATH)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(SolutionDir)\x64\Release;$(GLUT_ROOT)\lib;$(GLEW_ROOT)\lib;$(BOOST_ROOT)\stage\lib;$(SUITESPARSE_PATH)\lib64\lapack_blas_windows;$(SUITESPARSE_PATH)\lib64;$(OPENCV_PATH)\x64\vc12\lib;$(CERES_PATH)\lib;$(GLOG_PATH)\x64\Release;$(WXWIN)\lib\vc_x64_lib;$(LMDB_PATH)\X64\Release</AdditionalLibraryDirectories>
-      <AdditionalDependencies>MainEngine.lib;opencv_core300.lib;opencv_highgui300.lib;opencv_imgcodecs300.lib;opencv_imgproc300.lib;libblas.lib;liblapack.lib;libamdd.lib;libbtfd.lib;libcamd.lib;libccolamd.lib;libcholmod.lib;libcolamd.lib;libcxsparse.lib;libklu.lib;libldl.lib;libspqr.lib;libumfpack.lib;suitesparseconfig.lib;libglog.lib;ceres.lib;freeglut.lib;GLU32.lib;OPENGL32.lib;glew32.lib;Ws2_32.lib;wxmsw30u_core.lib;wxbase30u.lib;wxmsw30u_gl.lib;wxexpat.lib;wxjpeg.lib;wxpng.lib;wxregexu.lib;wxtiff.lib;wxzlib.lib;winmm.lib;comctl32.lib;rpcrt4.lib;wsock32.lib;odbc32.lib;libboost_filesystem-vc120-mt-1_59.lib;lmdb.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\x64\Release;$(GLUT_ROOT)\lib;$(GLEW_ROOT)\lib;$(BOOST_ROOT)\stage\lib;$(SUITESPARSE_PATH)\lib64\lapack_blas_windows;$(SUITESPARSE_PATH)\lib64;$(OPENCV_PATH)\x64\vc12\lib;$(CERES_PATH)\lib;$(GLOG_PATH)\x64\Release;$(WXWIN)\lib\vc_x64_lib;$(LMDB_PATH)\X64\Release;$(HDF5_PATH)\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>MainEngine.lib;opencv_core300.lib;opencv_highgui300.lib;opencv_imgcodecs300.lib;opencv_imgproc300.lib;libblas.lib;liblapack.lib;libamdd.lib;libbtfd.lib;libcamd.lib;libccolamd.lib;libcholmod.lib;libcolamd.lib;libcxsparse.lib;libklu.lib;libldl.lib;libspqr.lib;libumfpack.lib;suitesparseconfig.lib;libglog.lib;ceres.lib;freeglut.lib;GLU32.lib;OPENGL32.lib;glew32.lib;Ws2_32.lib;wxmsw30u_core.lib;wxbase30u.lib;wxmsw30u_gl.lib;wxexpat.lib;wxjpeg.lib;wxpng.lib;wxregexu.lib;wxtiff.lib;wxzlib.lib;winmm.lib;comctl32.lib;rpcrt4.lib;wsock32.lib;odbc32.lib;libboost_filesystem-vc120-mt-1_59.lib;lmdb.lib;libhdf5.lib;libhdf5_hl.lib;libhdf5_tools.lib;libszip.lib;libzlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/msvc/MainEngine/MainEngine.vcxproj
+++ b/msvc/MainEngine/MainEngine.vcxproj
@@ -88,7 +88,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;GLOG_NO_ABBREVIATED_SEVERITIES;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(LMDB_PATH)\liblmdb</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(LMDB_PATH)\liblmdb;$(HDF5_PATH)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -122,7 +122,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;GLOG_NO_ABBREVIATED_SEVERITIES;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(LMDB_PATH)\liblmdb</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\include;$(SolutionDir)\..\include\third_party;$(OPENCV_PATH)\include;$(EIGEN_PATH);$(EIGEN_PATH)\unsupported;$(BOOST_ROOT);$(SUITESPARSE_PATH)\include;$(CERES_PATH)\include;$(GLOG_PATH)\src\windows;$(GLUT_ROOT)\include;$(GLEW_ROOT)\include;$(LMDB_PATH)\liblmdb;$(HDF5_PATH)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -141,6 +141,7 @@
     <ClInclude Include="..\..\include\main_engine\rendering\DepthBuffer.h" />
     <ClInclude Include="..\..\include\main_engine\tracker\DeformNRSFMTracker.h" />
     <ClInclude Include="..\..\include\main_engine\tracker\FeaturePyramid.h" />
+    <ClInclude Include="..\..\include\main_engine\tracker\FeatureReader.h" />
     <ClInclude Include="..\..\include\main_engine\tracker\ImagePyramid.h" />
     <ClInclude Include="..\..\include\main_engine\tracker\Mesh.h" />
     <ClInclude Include="..\..\include\main_engine\tracker\MeshData.h" />
@@ -161,6 +162,7 @@
     <ClCompile Include="..\..\src\main_engine\rendering\DepthBuffer.cpp" />
     <ClCompile Include="..\..\src\main_engine\tracker\DeformNRSFMTracker.cpp" />
     <ClCompile Include="..\..\src\main_engine\tracker\FeaturePyramid.cpp" />
+    <ClCompile Include="..\..\src\main_engine\tracker\FeatureReader.cpp" />
     <ClCompile Include="..\..\src\main_engine\tracker\ImagePyramid.cpp" />
     <ClCompile Include="..\..\src\main_engine\tracker\Mesh.cpp" />
     <ClCompile Include="..\..\src\main_engine\tracker\MeshBufferReader.cpp" />

--- a/msvc/MainEngine/MainEngine.vcxproj.filters
+++ b/msvc/MainEngine/MainEngine.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClInclude Include="..\..\include\main_engine\tracker\FeaturePyramid.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\main_engine\tracker\FeatureReader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\main_engine\MainEngine.cpp">
@@ -123,6 +126,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\main_engine\tracker\FeaturePyramid.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main_engine\tracker\FeatureReader.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/main_engine/tracker/DeformNRSFMTracker.cpp
+++ b/src/main_engine/tracker/DeformNRSFMTracker.cpp
@@ -2719,7 +2719,7 @@ void DeformNRSFMTracker::AddTemporalMotionCost(ceres::Problem& problem,
       else
         {
           problemWrapper.addTemporalTerm(currLevel, residualBlockId);
-          problemWrapperGT.addRegTermCost(currLevel, cost_function);
+          problemWrapper.addRegTermCost(currLevel, cost_function);
         }
     }
 

--- a/src/main_engine/utils/global.cpp
+++ b/src/main_engine/utils/global.cpp
@@ -204,7 +204,7 @@ void process_mem_usage(double& vm_usage, double& resident_set)
 
    stat_stream.close();
 
-   long page_size_kb = sysconf(_SC_PAGE_SIZE) / 1024; // in case x86-64 is configured to use 2MB pages
+   long page_size_kb = (long)boost::interprocess::mapped_region::get_page_size() / 1024; // in case x86-64 is configured to use 2MB pages
    vm_usage     = vsize / 1024.0;
    resident_set = rss * page_size_kb;
 }


### PR DESCRIPTION
Solved memory leaks when reading and writing ply files:
- created destructor for structs PlyElement, PlyOtherProp, OtherData, OtherElem, PlyOtherElems, PlyFile.
- element names are now string instead of char\* to delegate its deallocation
- deleting list of elements after reading and updating ply.

Also:
- added HDF5 library to msvc solution
- using boost::interprocess::mapped_region to memory page size (compatible in unix and windows)
- change malloc function in nanoflann.hpp to avoid errors of reserved keyword
- fixed small bug in AddTemporalMotionCost (problemWrapperGT to problemWrapper)
